### PR TITLE
updated libraries

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,10 @@
 (defproject chortles "1.0.0"
   :description "Just for laughs"
   :url "http://chortles.herokuapp.com"
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [ring/ring-jetty-adapter "1.1.6"]
-                 [com.cemerick/drawbridge "0.0.6"]
-                 [ring-basic-authentication "1.0.1"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [ring/ring-jetty-adapter "1.7.1"]
+                 [nrepl/drawbridge "0.2.1"]
+                 [ring-basic-authentication "1.0.5"]]
+  :plugins [[nrepl/drawbridge "0.2.1"]]
   :min-lein-version "2.0.0"
   :main chortles.web)

--- a/src/chortles/web.clj
+++ b/src/chortles/web.clj
@@ -1,6 +1,6 @@
 (ns chortles.web
   (:require [ring.adapter.jetty :as jetty]
-            [cemerick.drawbridge :as drawbridge]
+            [drawbridge.core :as drawbridge]
             [ring.middleware.params :as params]
             [ring.middleware.keyword-params :as keyword-params]
             [ring.middleware.nested-params :as nested-params]
@@ -36,7 +36,7 @@
                    chortle magnitude (percentile magnitude))}))
 
 (def drawbridge-handler
-  (-> (cemerick.drawbridge/ring-handler)
+  (-> (drawbridge/ring-handler)
       (keyword-params/wrap-keyword-params)
       (nested-params/wrap-nested-params)
       (params/wrap-params)


### PR DESCRIPTION
* current version of used libraries
* nrepl/drawbridge instead of com.cemerick/drawbridge
* added :plugins [[nrepl/drawbridge "0.2.1"]]

`Using this changes it works with nREPL 0.6.0`